### PR TITLE
Floodstorm fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,14 @@ It is written in Python for Ryu framework, for use with OpenFlow 1.3.
 It has been tested in virtual _k_-ary FatTree topology with Ryu 4.23 and Mininet 2.2.2.
 
 This repository also includes Chadi Assi's presentation of the algorithm.
+
+## Changelog:
+* **Alpha Version 3**
+  * Fix ARP stormflood bug by dropping the ARP packets on core and aggregate switches instead of flooding them.
+  * Controller now generates requests on edge switches when receiving an ARP request.
+
+* **Alpha Version 2**
+  * Fix a lot of bugs from initial version
+
+* **Alpha Version 1**
+  * Initial Version

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ It has been tested in virtual _k_-ary FatTree topology with Ryu 4.23 and Mininet
 This repository also includes Chadi Assi's presentation of the algorithm.
 
 ## Changelog:
-* **Alpha Version 3**
+* **Alpha Version 3 - 2018.10.28**
   * Fix ARP stormflood bug by dropping the ARP packets on core and aggregate switches instead of flooding them.
   * Controller now generates requests on edge switches when receiving an ARP request.
 
-* **Alpha Version 2**
+* **Alpha Version 2 - 2018.10.25**
   * Fix a lot of bugs from initial version
 
-* **Alpha Version 1**
+* **Alpha Version 1 - 2018.10.15**
   * Initial Version


### PR DESCRIPTION
Fixed a bug that caused ARP packets to floodstorm the topology. The core and aggregate switches now drop the ARP packets (not the ICMP packets), and the controller generates requests on the edge switches when receiving an ARP packet from the host. :wink: 